### PR TITLE
PHPUnit テストの WordPress のバージョン変更

### DIFF
--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['7.4', '8.0', '8.1']
-                wp-versions: ['6.0.3', '6.1.1', '6.2']
+                wp-versions: ['6.3', '6.4', '6.5']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:

--- a/.github/workflows/wp-plugin-deploy.yml
+++ b/.github/workflows/wp-plugin-deploy.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
         matrix:
             php-versions: ['7.4', '8.0', '8.1']
-            wp-versions: ['6.0.3', '6.1.1', '6.2']
+            wp-versions: ['6.3', '6.4', '6.5']
     name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
     services:
         mysql:


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

PHPUnit で実行させる WordPress のバージョンが古かったので変更