### PR TITLE
Fixed an issue that occurred in a PHP 8.0 or higher environment.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,8 @@ But we have a .pot file available so feel free to translate it in your language 
 
 == Changelog ==
 
+* [ Bug fix ] Fixed an issue that occurred in a PHP 8.0 or higher environment.
+
 = 1.7.2 =
 * [ Other ] Update admin settingpage library 2.6.0
 

--- a/tests/phpunit/test-rewrite.php
+++ b/tests/phpunit/test-rewrite.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Class rewriteTest
+ *
+ * @package Vk_Link_Target_Controller
+ */
+
+/**
+ * Option test case.
+ */
+class rewriteTest extends WP_UnitTestCase {
+
+	/**
+	 * PHP Unit テストにあたって、各種投稿やカスタム投稿タイプ、カテゴリーを登録します。
+	 *
+	 * @return array $test_posts : 作成した投稿の記事idなどを配列で返します。
+	 */
+	public static function create_test_posts() {
+
+		$test_posts = array();
+
+		/******************************************
+		 * テスト用投稿の登録 */
+
+		// 通常の投稿 Test Post を投稿.
+		$post                  = array(
+			'post_title'   => 'Test Post',
+			'post_status'  => 'publish',
+			'post_content' => 'content',
+		);
+		$test_posts['post_id'] = wp_insert_post( $post );
+		return $test_posts;
+	}
+
+
+	/**
+	 *
+	 */
+	function test_rewrite() {
+
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'rewrite_link_filter()' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+
+		// Create test posts.
+		$test_posts = self::create_test_posts();
+
+		$post = get_post( $test_posts['post_id'] );
+
+		$test_array = array(
+			array(
+				'original' => get_permalink( $test_posts['post_id'] ),
+				'expected' => get_permalink( $test_posts['post_id'] ),
+			),
+			array(
+				'original'  => get_permalink( $test_posts['post_id'] ),
+				'post_meta' => array(
+					'vk-ltc-link' => 'https://google.com',
+				),
+				'expected'  => 'https://google.com',
+			),
+		);
+		$instance   = new VK_Link_Target_Controller();
+		foreach ( $test_array as $key => $value ) {
+			if ( isset( $value['post_meta']['vk-ltc-link'] ) ) {
+				update_post_meta( $test_posts['post_id'], 'vk-ltc-link', $value['post_meta']['vk-ltc-link'] );
+			} else {
+				delete_post_meta( $test_posts['post_id'], 'vk-ltc-link' );
+			}
+			$actual = $instance->rewrite_link_filter( $value['original'], $post );
+
+			print 'actual   :' . $actual . PHP_EOL;
+			print 'expected :' . $value['expected'] . PHP_EOL;
+
+			$this->assertEquals( $value['expected'], $actual );
+		}
+
+		wp_delete_post( $test_posts['post_id'], true );
+	}
+}


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

PHP 8.0 でリンクURLを返さなくなる

https://github.com/vektor-inc/vk-link-target-controller/issues/62

## どういう変更をしたか？

* PHP 8.0 以降では  the_permalink フィルタの中に global $post が落ちてこなくなるため
* そもそも the_permalink フィルタ使う時点で $post を受け取れるのでそこから処理するように変更

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？


## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* Nishiki など Vektor 製以外のテーマで指定のページにリンクする事を確認
  （href 自体は切り替わっていないので、それは[別 issue で対応](https://github.com/vektor-inc/vk-link-target-controller/issues/79)）
 * composer install / wp-env start / npm run phpunit