### PR TITLE
[ 開発環境 ] CI/CDワークフローをフェーズ0 C-7 要件に対応

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,13 +121,16 @@ jobs:
               with:
                   name: dist
                   path: dist/
+            - name: Copy test dependencies into dist for phpunit
+              run: |
+                  cp -r vendor dist/${{ env.plugin_name }}/vendor
+                  for f in .phpunit.xml phpunit.xml phpunit.xml.dist; do
+                    [ -f "$f" ] && cp "$f" "dist/${{ env.plugin_name }}/$f" || true
+                  done
+                  [ -d tests ] && cp -r tests "dist/${{ env.plugin_name }}/tests" || true
             - name: Create wp-env.override.json for dist
               run: |
-                  cat > wp-env.override.json << 'EOF'
-                  {
-                    "plugins": ["./dist/${{ env.plugin_name }}"]
-                  }
-                  EOF
+                  printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > wp-env.override.json
             - name: Install several WordPress version by wp-env.override.json
               run: |
                   n=0


### PR DESCRIPTION
## 概要

vektor-inc/multi-repo-tasks#5 の対応。

フェーズ0 C-7 要件に未対応だったCI/CDワークフローを修正。

## 変更内容

- `build_dist` ジョブを新規追加（dist 作成・upload-artifact）
- `smoke_test` ジョブで dist artifact をダウンロードしてスモークテスト実行
- PHPUnit を dist に対してテストするよう修正（ソースコードではなく配布物でテスト）
- `php_unit` ジョブに dist へテスト依存ファイル（`vendor/`・`tests/`・phpunit設定）をコピーするステップを追加
- `upload-artifact` / `download-artifact` でジョブ間のアーティファクト共有を実現
- deploy/release ジョブで再ビルドせず build_dist で作成した dist を使用
- wp-env のリトライループに `exit 1` を追加

## テスト

- [ ] ワークフローの YAML 構文が正しいか確認
- [ ] deploy/release ジョブで `npm run dist` を再実行していないことを確認

関連: vektor-inc/multi-repo-tasks#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)