### PR TITLE
[ その他 ] readme.txt に Stable tag を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@ Donate link:
 Tags: redirection,link,recent posts,list,page,post
 Requires at least: 5.3
 Tested up to: 6.9
+Stable tag: 1.8.0.1
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- readme.txt に `Stable tag: 1.8.0.1` を追加
- `Stable tag` が欠落していると WordPress.org のビルドシステムが zip を正しく再生成せず、古いバージョンが配信され続ける問題への対応

Related: vektor-inc/multi-repo-tasks#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バージョン1.8.0.1のメタデータを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->