### PR TITLE
[ その他 ] プラグイン説明のサンプルコードを修正（class属性が必要なのにidと記載されていた問題）

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Japanese characters in urls are supported.
 
 VK Link Target Controller adds a filter on the `the_permalink()` WordPress function, which means the redirection won't work if your theme uses another function, for example `get_permalink()` to display the links.
 
-In order to have the link opened in a new window VK Link Target Controller needs a theme with the post id as id on the <a> parent element.
+In order to have the link opened in a new window VK Link Target Controller needs a theme with the post id as class on the <a> parent element.
 
 Your theme probably has it if it follows the WordPress Theme recommendations.
 
 Example:
 ```
-<div class="post-item post-block front-page-list" id="post-<?php the_ID(); ?>">
+<div class="post-item post-block front-page-list post-<?php the_ID(); ?>" id="post-<?php the_ID(); ?>">
  <a href="<?php the permalink(); ?>">
   <?php the_title(); ?>
  </a>

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ In order to have the link opened in a new window VK Link Target Controller needs
 Your theme probably has it if it follows the WordPress Theme recommendations.
 
 Example:
-```
+```php
 <div class="post-item post-block front-page-list post-<?php the_ID(); ?>" id="post-<?php the_ID(); ?>">
  <a href="<?php the permalink(); ?>">
   <?php the_title(); ?>

--- a/readme.txt
+++ b/readme.txt
@@ -82,7 +82,7 @@ VK Link Target Controller supports Japanese in URLs so probably you can add othe
 = My link won't open on a new window. =
 
 VK Link Target Controller adds a filter on the `the_permalink()` WordPress function, which means the redirection won't work if your theme uses another function, for example `get_permalink()` to display the links.
-In order to have the link opened in a new window VK Link Target Controller needs a theme with the post id as id on the `<a>` parent element.
+In order to have the link opened in a new window VK Link Target Controller needs a theme with the post id as class on the `<a>` parent element.
 
 Your theme probably has it if it follows the WordPress Theme recommendations.
 
@@ -120,6 +120,7 @@ But we have a .pot file available so feel free to translate it in your language 
 == Changelog ==
 
 * [ Add Function ] Show an edit link next to post titles for logged-in users who have edit permission, when a redirect URL is set on the post.
+* [ Other ] Fix incorrect sample code in plugin description (class attribute is required, not id).
 
 = 1.9.0 =
 * [ Specification change ] Migrate meta box to block editor native sidebar panel for WordPress 7.0 RTC (Real-Time Collaboration) compatibility.


### PR DESCRIPTION
## 概要

.org のプラグイン説明ページおよび README.md のサンプルコード・説明文が、実際の JS の動作と一致していなかった問題を修正。

JS コード（`js/script.js`）は `$('.post-' + id)` で **class** 属性を参照しているが、ドキュメントでは「post id as **id** on the `<a>` parent element」と記載されており、ユーザーが `id` 属性のみを付与してハマるケースが報告された（#97）。

### 変更内容

- **readme.txt**: 説明文の `as id` → `as class` に修正
- **README.md**: 説明文の `as id` → `as class` に修正、サンプルコードに `post-<?php the_ID(); ?>` class を追加
- **changelog**: `[ Other ] Fix incorrect sample code in plugin description (class attribute is required, not id).` を追記

Closes #97

## 確認手順

### 前提条件
- なし（ドキュメントのみの修正）

### 手順

1. `readme.txt` の 85行目付近を確認する
   → `as class on the` と記載されていること（`as id` ではない）
2. `readme.txt` の Example A（91行目付近）のサンプルコードを確認する
   → `class="post-item post-block front-page-list post-<?php the_ID(); ?>"` のように class に `post-<?php the_ID(); ?>` が含まれていること
3. `readme.txt` の Example B（100行目付近）のサンプルコードを確認する
   → `get_post_class()` を使用しており、class に post-{ID} が含まれる旨の説明があること
4. `README.md` の Theme compatibility セクションの説明文を確認する
   → `as class on the <a> parent element` と記載されていること
5. `README.md` のサンプルコードを確認する
   → `class="post-item post-block front-page-list post-<?php the_ID(); ?>"` のように class に `post-<?php the_ID(); ?>` が含まれていること
6. `js/script.js` の45行目付近を確認する
   → `$('.post-' + id)` でclass参照していることと、ドキュメントの説明が一致していること
7. `readme.txt` の changelog セクションを確認する
   → `* [ Other ] Fix incorrect sample code in plugin description (class attribute is required, not id).` が追記されていること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * テーマの互換性ガイダンスを更新しました。リンクを新しいウィンドウで開く機能について、投稿 ID の指定方法を変更しました。
  * サンプルコードと FAQ を更新し、正しい実装方法を反映させました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->