### PR TITLE
[ 機能追加 ] プラグイン削除時にDB内のプラグイン固有データを掃除する処理を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,7 @@ But we have a .pot file available so feel free to translate it in your language 
 == Changelog ==
 
 * [ Add Function ] Show an edit link next to post titles for logged-in users who have edit permission, when a redirect URL is set on the post.
+* [ New Feature ] Clean up plugin-specific data (post meta and options) from the database when the plugin is deleted.
 
 = 1.9.0 =
 * [ Specification change ] Migrate meta box to block editor native sidebar panel for WordPress 7.0 RTC (Real-Time Collaboration) compatibility.

--- a/tests/phpunit/test-uninstall.php
+++ b/tests/phpunit/test-uninstall.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Test uninstall cleanup functionality.
+ * アンインストール時のDB掃除機能のテスト。
+ *
+ * @package vk-link-target-controller
+ */
+
+/**
+ * Uninstall test case.
+ * アンインストールのテストケース。
+ */
+class UninstallTest extends WP_UnitTestCase {
+
+	/**
+	 * Test that uninstall.php removes post meta and options from the database.
+	 * uninstall.php が投稿メタとオプションをデータベースから削除することをテストする。
+	 */
+	function test_uninstall() {
+
+		// Test data setup: create posts and set plugin-specific post meta.
+		// テストデータの準備：投稿を作成し、プラグイン固有の投稿メタを設定する。
+		$post_id_1 = $this->factory->post->create();
+		$post_id_2 = $this->factory->post->create();
+
+		// テストケースの配列
+		// Test cases array.
+		$test_cases = array(
+			array(
+				'test_condition_name' => '投稿メタとオプションが設定されている状態でアンインストールを実行した場合 => 全て削除される',
+				'conditions'         => array(
+					'post_meta' => array(
+						$post_id_1 => array(
+							'vk-ltc-link'   => 'https://example.com/',
+							'vk-ltc-target' => '1',
+						),
+						$post_id_2 => array(
+							'vk-ltc-link'   => 'https://example.org/page',
+							'vk-ltc-target' => '0',
+						),
+					),
+					'options'   => array(
+						'custom-post-types' => array( 'post', 'page' ),
+					),
+				),
+				'expected'           => array(
+					'post_meta_link_1'   => '',
+					'post_meta_target_1' => '',
+					'post_meta_link_2'   => '',
+					'post_meta_target_2' => '',
+					'option'             => false,
+				),
+			),
+			array(
+				'test_condition_name' => '片方の投稿にのみメタが設定されている状態でアンインストールを実行した場合 => 全て削除される',
+				'conditions'         => array(
+					'post_meta' => array(
+						$post_id_1 => array(
+							'vk-ltc-link'   => 'https://example.com/single',
+							'vk-ltc-target' => '1',
+						),
+					),
+					'options'   => array(
+						'custom-post-types' => array( 'post' ),
+					),
+				),
+				'expected'           => array(
+					'post_meta_link_1'   => '',
+					'post_meta_target_1' => '',
+					'post_meta_link_2'   => '',
+					'post_meta_target_2' => '',
+					'option'             => false,
+				),
+			),
+			array(
+				'test_condition_name' => 'メタもオプションも存在しない状態でアンインストールを実行した場合 => エラーなく完了する',
+				'conditions'         => array(
+					'post_meta' => array(),
+					'options'   => array(),
+				),
+				'expected'           => array(
+					'post_meta_link_1'   => '',
+					'post_meta_target_1' => '',
+					'post_meta_link_2'   => '',
+					'post_meta_target_2' => '',
+					'option'             => false,
+				),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+
+			// Set up conditions: post meta.
+			// 条件の設定：投稿メタ。
+			if ( ! empty( $case['conditions']['post_meta'] ) ) {
+				foreach ( $case['conditions']['post_meta'] as $pid => $metas ) {
+					foreach ( $metas as $meta_key => $meta_value ) {
+						update_post_meta( $pid, $meta_key, $meta_value );
+					}
+				}
+			}
+
+			// Set up conditions: options.
+			// 条件の設定：オプション。
+			if ( ! empty( $case['conditions']['options'] ) ) {
+				foreach ( $case['conditions']['options'] as $option_name => $option_value ) {
+					update_option( $option_name, $option_value );
+				}
+			}
+
+			// Define WP_UNINSTALL_PLUGIN if not already defined, then include uninstall.php.
+			// WP_UNINSTALL_PLUGIN が未定義の場合は定義し、uninstall.php を読み込む。
+			if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+				define( 'WP_UNINSTALL_PLUGIN', true );
+			}
+			include dirname( dirname( __DIR__ ) ) . '/uninstall.php';
+
+			// Assert post meta is deleted.
+			// 投稿メタが削除されていることを確認する。
+			$this->assertSame(
+				$case['expected']['post_meta_link_1'],
+				get_post_meta( $post_id_1, 'vk-ltc-link', true ),
+				$case['test_condition_name'] . ' (vk-ltc-link post 1)'
+			);
+			$this->assertSame(
+				$case['expected']['post_meta_target_1'],
+				get_post_meta( $post_id_1, 'vk-ltc-target', true ),
+				$case['test_condition_name'] . ' (vk-ltc-target post 1)'
+			);
+			$this->assertSame(
+				$case['expected']['post_meta_link_2'],
+				get_post_meta( $post_id_2, 'vk-ltc-link', true ),
+				$case['test_condition_name'] . ' (vk-ltc-link post 2)'
+			);
+			$this->assertSame(
+				$case['expected']['post_meta_target_2'],
+				get_post_meta( $post_id_2, 'vk-ltc-target', true ),
+				$case['test_condition_name'] . ' (vk-ltc-target post 2)'
+			);
+
+			// Assert option is deleted.
+			// オプションが削除されていることを確認する。
+			$this->assertSame(
+				$case['expected']['option'],
+				get_option( 'custom-post-types', false ),
+				$case['test_condition_name'] . ' (custom-post-types option)'
+			);
+
+			// Clean up for next iteration: delete any remaining meta and options.
+			// 次のイテレーションのためにクリーンアップ：残っているメタとオプションを削除する。
+			delete_post_meta( $post_id_1, 'vk-ltc-link' );
+			delete_post_meta( $post_id_1, 'vk-ltc-target' );
+			delete_post_meta( $post_id_2, 'vk-ltc-link' );
+			delete_post_meta( $post_id_2, 'vk-ltc-target' );
+			delete_option( 'custom-post-types' );
+		}
+	}
+}

--- a/tests/phpunit/test-uninstall.php
+++ b/tests/phpunit/test-uninstall.php
@@ -113,29 +113,45 @@ class UninstallTest extends WP_UnitTestCase {
 			if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 				define( 'WP_UNINSTALL_PLUGIN', true );
 			}
-			include dirname( dirname( __DIR__ ) ) . '/uninstall.php';
+			require dirname( dirname( __DIR__ ) ) . '/uninstall.php';
 
-			// Assert post meta is deleted.
-			// 投稿メタが削除されていることを確認する。
+			// Assert post meta is deleted using both get_post_meta and metadata_exists.
+			// get_post_meta と metadata_exists の両方を使って投稿メタが削除されていることを確認する。
 			$this->assertSame(
 				$case['expected']['post_meta_link_1'],
 				get_post_meta( $post_id_1, 'vk-ltc-link', true ),
 				$case['test_condition_name'] . ' (vk-ltc-link post 1)'
+			);
+			$this->assertFalse(
+				metadata_exists( 'post', $post_id_1, 'vk-ltc-link' ),
+				$case['test_condition_name'] . ' (vk-ltc-link post 1 should be deleted)'
 			);
 			$this->assertSame(
 				$case['expected']['post_meta_target_1'],
 				get_post_meta( $post_id_1, 'vk-ltc-target', true ),
 				$case['test_condition_name'] . ' (vk-ltc-target post 1)'
 			);
+			$this->assertFalse(
+				metadata_exists( 'post', $post_id_1, 'vk-ltc-target' ),
+				$case['test_condition_name'] . ' (vk-ltc-target post 1 should be deleted)'
+			);
 			$this->assertSame(
 				$case['expected']['post_meta_link_2'],
 				get_post_meta( $post_id_2, 'vk-ltc-link', true ),
 				$case['test_condition_name'] . ' (vk-ltc-link post 2)'
 			);
+			$this->assertFalse(
+				metadata_exists( 'post', $post_id_2, 'vk-ltc-link' ),
+				$case['test_condition_name'] . ' (vk-ltc-link post 2 should be deleted)'
+			);
 			$this->assertSame(
 				$case['expected']['post_meta_target_2'],
 				get_post_meta( $post_id_2, 'vk-ltc-target', true ),
 				$case['test_condition_name'] . ' (vk-ltc-target post 2)'
+			);
+			$this->assertFalse(
+				metadata_exists( 'post', $post_id_2, 'vk-ltc-target' ),
+				$case['test_condition_name'] . ' (vk-ltc-target post 2 should be deleted)'
 			);
 
 			// Assert option is deleted.

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Uninstall handler for VK Link Target Controller.
+ * VK Link Target Controller のアンインストール処理。
+ *
+ * Fired when the plugin is deleted via the WordPress admin.
+ * WordPress管理画面からプラグインを削除した際に実行される。
+ *
+ * Removes all plugin-specific data from the database:
+ * データベースからプラグイン固有のデータを全て削除する:
+ * - post meta: vk-ltc-link, vk-ltc-target
+ * - option: custom-post-types
+ *
+ * @package vk-link-target-controller
+ */
+
+// Exit if not called by WordPress uninstall process.
+// WordPress のアンインストールプロセスから呼ばれていない場合は終了する。
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+/**
+ * Delete all post meta entries created by this plugin.
+ * このプラグインが作成した全ての投稿メタを削除する。
+ *
+ * Uses delete_post_meta_by_key() to efficiently remove all rows
+ * for each meta key from the postmeta table.
+ * delete_post_meta_by_key() を使用して、postmeta テーブルから
+ * 各メタキーの全行を効率的に削除する。
+ */
+delete_post_meta_by_key( 'vk-ltc-link' );
+delete_post_meta_by_key( 'vk-ltc-target' );
+
+/**
+ * Delete plugin options from the options table.
+ * オプションテーブルからプラグインのオプションを削除する。
+ */
+delete_option( 'custom-post-types' );


### PR DESCRIPTION
## 概要

プラグインを WordPress 管理画面から削除した際に、データベースに残っているプラグイン固有のデータ（post meta・option）を自動的に削除する `uninstall.php` を追加しました。

Closes #12

## 変更内容

### 新規作成: `uninstall.php`
- `WP_UNINSTALL_PLUGIN` 定義チェックによるセキュリティガード
- `delete_post_meta_by_key('vk-ltc-link')` で全投稿の `vk-ltc-link` メタを削除
- `delete_post_meta_by_key('vk-ltc-target')` で全投稿の `vk-ltc-target` メタを削除
- `delete_option('custom-post-types')` でプラグインオプションを削除

### 新規作成: `tests/phpunit/test-uninstall.php`
- 両方の投稿にメタがある場合のテスト
- 片方の投稿のみにメタがある場合のテスト
- メタもオプションも存在しない場合のテスト（エラーなく完了することを確認）

### 更新: `readme.txt`
- changelog に `[ New Feature ]` エントリを追加

## 確認手順

### 前提条件
- WordPress のローカル開発環境（wp-env / Docker 等）
- VK Link Target Controller プラグインがインストール済み
- 投稿が2件以上存在すること

### 手順

1. VK Link Target Controller プラグインを有効化する
2. 管理画面 > 設定 > Link Target Controller で、対象の投稿タイプ（例: `投稿`）にチェックを入れて保存する
3. 投稿編集画面を開き、サイドバーの「VK Link Target Controller」パネルでリダイレクトURLを入力して保存する（例: `https://example.com/`）
4. 別の投稿でも同様にリダイレクトURLを設定する
5. データベースを確認し、`wp_postmeta` テーブルに `vk-ltc-link` と `vk-ltc-target` のレコードが存在することを確認する
   → ✓ メタデータが保存されている
6. `wp_options` テーブルに `custom-post-types` のレコードが存在することを確認する
   → ✓ オプションが保存されている
7. 管理画面 > プラグイン でプラグインを「無効化」する
8. プラグイン一覧で「削除」をクリックし、確認ダイアログで「はい、これらのファイルを削除します」をクリックする
9. データベースの `wp_postmeta` テーブルを確認する
   → ✓ `vk-ltc-link` と `vk-ltc-target` のレコードが全て削除されている
10. データベースの `wp_options` テーブルを確認する
    → ✓ `custom-post-types` のレコードが削除されている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プラグイン削除時にプラグイン固有の投稿メタやプラグイン設定（オプション）を自動的にクリーンアップするアンインストール処理を追加しました。

* **テスト**
  * アンインストール処理が該当データを確実に削除することを検証する単体テストを追加しました。

* **ドキュメント**
  * チェンジログに新バージョンのアンインストール動作を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->