### PR TITLE
[ 仕様変更 ] オプションキー 'custom-post-types' をプレフィックス付きキー 'vk_ltc_custom_post_types' に変更

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,7 @@ But we have a .pot file available so feel free to translate it in your language 
 
 == Changelog ==
 
+* [ Spec Change ] Rename option key from 'custom-post-types' to 'vk_ltc_custom_post_types' to avoid conflicts with other plugins. Existing data is automatically migrated.
 * [ Add Function ] Show an edit link next to post titles for logged-in users who have edit permission, when a redirect URL is set on the post.
 * [ New Feature ] Clean up plugin-specific data (post meta and options) from the database when the plugin is deleted.
 * [ Other ] Fix incorrect sample code in plugin description (class attribute is required, not id).

--- a/readme.txt
+++ b/readme.txt
@@ -119,7 +119,7 @@ But we have a .pot file available so feel free to translate it in your language 
 
 == Changelog ==
 
-* [ Spec Change ] Rename option key from 'custom-post-types' to 'vk_ltc_custom_post_types' to avoid conflicts with other plugins. Existing data is automatically migrated.
+* [ Spec Change ] Rename option key from 'custom-post-types' to 'vk_ltc_custom_post_types' to avoid conflicts with other plugins. Existing data is automatically migrated. Added fallback to legacy key for frontend requests before admin_init migration runs.
 * [ Add Function ] Show an edit link next to post titles for logged-in users who have edit permission, when a redirect URL is set on the post.
 * [ New Feature ] Clean up plugin-specific data (post meta and options) from the database when the plugin is deleted.
 * [ Other ] Fix incorrect sample code in plugin description (class attribute is required, not id).

--- a/tests/phpunit/test-option.php
+++ b/tests/phpunit/test-option.php
@@ -65,6 +65,7 @@ class OptionTest extends WP_UnitTestCase {
 			// Ensure the option does not exist before each iteration.
 			// 各イテレーション前にオプションが存在しない状態にする。
 			delete_option( 'vk_ltc_custom_post_types' );
+			delete_option( 'custom-post-types' );
 
 			// Only save the option when the test fixture provides a value (not false).
 			// テストフィクスチャが値を提供する場合（false でない場合）のみオプションを保存する。
@@ -80,6 +81,7 @@ class OptionTest extends WP_UnitTestCase {
 			// Clean up option for next iteration.
 			// 次のイテレーションのためにオプションをクリーンアップする。
 			delete_option( 'vk_ltc_custom_post_types' );
+			delete_option( 'custom-post-types' );
 		}
 	}
 

--- a/tests/phpunit/test-option.php
+++ b/tests/phpunit/test-option.php
@@ -75,6 +75,96 @@ class OptionTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that get_option() falls back to the legacy option key when the new key does not exist.
+	 * get_option() が新キーが存在しない場合に旧キーにフォールバックすることをテストする。
+	 *
+	 * This covers the scenario where the plugin is updated but admin_init has not yet run
+	 * (e.g., a frontend request immediately after update), so the migration has not occurred.
+	 * プラグイン更新直後に admin_init がまだ実行されていない場合（例：更新直後のフロントエンドリクエスト）の
+	 * シナリオをカバーする。
+	 */
+	function test_get_option_legacy_key_fallback() {
+
+		// Register a custom post type for testing.
+		// テスト用カスタム投稿タイプを登録する。
+		register_post_type(
+			'event',
+			array(
+				'has_archive' => true,
+				'public'      => true,
+			)
+		);
+
+		$old_key = 'custom-post-types';
+		$new_key = 'vk_ltc_custom_post_types';
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => 'Only legacy key exists => should return legacy key value',
+				'conditions'          => array(
+					'old_key_value' => array( 'post', 'page' ),
+					'new_key_value' => null,
+				),
+				'expected'            => array( 'post', 'page' ),
+			),
+			array(
+				'test_condition_name' => 'Both keys exist => should return new key value (new key takes priority)',
+				'conditions'          => array(
+					'old_key_value' => array( 'post' ),
+					'new_key_value' => array( 'post', 'page', 'event' ),
+				),
+				'expected'            => array( 'post', 'page', 'event' ),
+			),
+			array(
+				'test_condition_name' => 'Neither key exists => should return all public post type slugs as default',
+				'conditions'          => array(
+					'old_key_value' => null,
+					'new_key_value' => null,
+				),
+				'expected'            => array( 'post', 'event', 'page' ),
+			),
+			array(
+				'test_condition_name' => 'Only new key exists => should return new key value',
+				'conditions'          => array(
+					'old_key_value' => null,
+					'new_key_value' => array( 'event' ),
+				),
+				'expected'            => array( 'event' ),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+
+			// Set up conditions.
+			// 条件の設定。
+			if ( null !== $case['conditions']['old_key_value'] ) {
+				update_option( $old_key, $case['conditions']['old_key_value'] );
+			}
+			if ( null !== $case['conditions']['new_key_value'] ) {
+				update_option( $new_key, $case['conditions']['new_key_value'] );
+			}
+
+			// Execute get_option() method.
+			// get_option() メソッドを実行する。
+			$instance = new VK_Link_Target_Controller();
+			$result   = $instance->get_option();
+
+			// Assert the returned value matches the expected value.
+			// 返り値が期待値と一致することを検証する。
+			$this->assertSame(
+				$case['expected'],
+				$result,
+				$case['test_condition_name']
+			);
+
+			// Clean up for next iteration.
+			// 次のイテレーションのためにクリーンアップする。
+			delete_option( $old_key );
+			delete_option( $new_key );
+		}
+	}
+
+	/**
 	 * Test that vk_ltc_migrate_option_key() migrates the old option key to the new one.
 	 * vk_ltc_migrate_option_key() が旧オプションキーを新オプションキーに移行することをテストする。
 	 */

--- a/tests/phpunit/test-option.php
+++ b/tests/phpunit/test-option.php
@@ -62,7 +62,16 @@ class OptionTest extends WP_UnitTestCase {
 			),
 		);
 		foreach ( $test_array as $key => $value ) {
-			update_option( 'vk_ltc_custom_post_types', $value['options'] );
+			// Ensure the option does not exist before each iteration.
+			// 各イテレーション前にオプションが存在しない状態にする。
+			delete_option( 'vk_ltc_custom_post_types' );
+
+			// Only save the option when the test fixture provides a value (not false).
+			// テストフィクスチャが値を提供する場合（false でない場合）のみオプションを保存する。
+			if ( false !== $value['options'] ) {
+				update_option( 'vk_ltc_custom_post_types', $value['options'] );
+			}
+
 			$instanse = new VK_Link_Target_Controller();
 			$result   = $instanse->get_option();
 			$correct  = $value['correct'];
@@ -130,6 +139,33 @@ class OptionTest extends WP_UnitTestCase {
 					'new_key_value' => array( 'event' ),
 				),
 				'expected'            => array( 'event' ),
+			),
+			array(
+				'test_condition_name' => 'Only legacy key exists with empty array => should return empty array, not defaults',
+				// 旧キーに空配列が保存、新キーなし => デフォルトではなく空配列を返す。
+				'conditions'          => array(
+					'old_key_value' => array(),
+					'new_key_value' => null,
+				),
+				'expected'            => array(),
+			),
+			array(
+				'test_condition_name' => 'Only new key exists with empty array => should return empty array, not defaults',
+				// 新キーに空配列が保存、旧キーなし => デフォルトではなく空配列を返す。
+				'conditions'          => array(
+					'old_key_value' => null,
+					'new_key_value' => array(),
+				),
+				'expected'            => array(),
+			),
+			array(
+				'test_condition_name' => 'Both keys exist with empty arrays => should return new key empty array',
+				// 新旧両方に空配列が保存 => 新キーの空配列を返す。
+				'conditions'          => array(
+					'old_key_value' => array(),
+					'new_key_value' => array(),
+				),
+				'expected'            => array(),
 			),
 		);
 
@@ -215,6 +251,19 @@ class OptionTest extends WP_UnitTestCase {
 				),
 				'expected'           => array(
 					'new_key_value'    => array( 'event' ),
+					'old_key_exists'   => false,
+				),
+			),
+			array(
+				'test_condition_name' => '旧キーに空配列が保存されている場合 => 空配列のまま新キーへ移行される',
+				// Falsy value (empty array) should be migrated correctly, not treated as missing.
+				// falsy 値（空配列）は欠損として扱わず正しく移行される。
+				'conditions'         => array(
+					'old_key_value' => array(),
+					'new_key_value' => null,
+				),
+				'expected'           => array(
+					'new_key_value'    => array(),
 					'old_key_exists'   => false,
 				),
 			),

--- a/tests/phpunit/test-option.php
+++ b/tests/phpunit/test-option.php
@@ -11,10 +11,10 @@
 class OptionTest extends WP_UnitTestCase {
 
 	/**
-	 * A single example test.
+	 * Test that get_option() returns the correct post types based on saved option.
+	 * get_option() が保存されたオプションに基づいて正しい投稿タイプを返すことをテストする。
 	 */
-	function test_option() {
-		// Replace this with some actual testing code.
+	function test_get_option() {
 
 		/**
 		 * カスタム投稿タイプを設置
@@ -62,12 +62,112 @@ class OptionTest extends WP_UnitTestCase {
 			),
 		);
 		foreach ( $test_array as $key => $value ) {
-			update_option( 'custom-post-types', $value['options'] );
+			update_option( 'vk_ltc_custom_post_types', $value['options'] );
 			$instanse = new VK_Link_Target_Controller();
 			$result   = $instanse->get_option();
 			$correct  = $value['correct'];
 			$this->assertEquals( $correct, $result );
 
+			// Clean up option for next iteration.
+			// 次のイテレーションのためにオプションをクリーンアップする。
+			delete_option( 'vk_ltc_custom_post_types' );
+		}
+	}
+
+	/**
+	 * Test that vk_ltc_migrate_option_key() migrates the old option key to the new one.
+	 * vk_ltc_migrate_option_key() が旧オプションキーを新オプションキーに移行することをテストする。
+	 */
+	function test_vk_ltc_migrate_option_key() {
+
+		$old_key = 'custom-post-types';
+		$new_key = 'vk_ltc_custom_post_types';
+
+		$test_cases = array(
+			array(
+				'test_condition_name' => '旧キーが存在し新キーが存在しない場合 => 旧キーの値が新キーに移行され、旧キーが削除される',
+				'conditions'         => array(
+					'old_key_value' => array( 'post', 'page' ),
+					'new_key_value' => null,
+				),
+				'expected'           => array(
+					'new_key_value'    => array( 'post', 'page' ),
+					'old_key_exists'   => false,
+				),
+			),
+			array(
+				'test_condition_name' => '旧キーが存在し新キーも既に存在する場合 => 新キーの値は上書きされず、旧キーのみ削除される',
+				'conditions'         => array(
+					'old_key_value' => array( 'post' ),
+					'new_key_value' => array( 'post', 'page', 'event' ),
+				),
+				'expected'           => array(
+					'new_key_value'    => array( 'post', 'page', 'event' ),
+					'old_key_exists'   => false,
+				),
+			),
+			array(
+				'test_condition_name' => '旧キーが存在しない場合 => 何も変更されない',
+				'conditions'         => array(
+					'old_key_value' => null,
+					'new_key_value' => null,
+				),
+				'expected'           => array(
+					'new_key_value'    => false,
+					'old_key_exists'   => false,
+				),
+			),
+			array(
+				'test_condition_name' => '旧キーが存在せず新キーが既に存在する場合 => 新キーの値はそのまま保持される',
+				'conditions'         => array(
+					'old_key_value' => null,
+					'new_key_value' => array( 'event' ),
+				),
+				'expected'           => array(
+					'new_key_value'    => array( 'event' ),
+					'old_key_exists'   => false,
+				),
+			),
+		);
+
+		foreach ( $test_cases as $case ) {
+
+			// Set up conditions.
+			// 条件の設定。
+			if ( null !== $case['conditions']['old_key_value'] ) {
+				update_option( $old_key, $case['conditions']['old_key_value'] );
+			}
+			if ( null !== $case['conditions']['new_key_value'] ) {
+				update_option( $new_key, $case['conditions']['new_key_value'] );
+			}
+
+			// Execute migration function.
+			// 移行関数を実行する。
+			vk_ltc_migrate_option_key();
+
+			// Assert new key value.
+			// 新キーの値を検証する。
+			$this->assertSame(
+				$case['expected']['new_key_value'],
+				get_option( $new_key, false ),
+				$case['test_condition_name'] . ' (new key value)'
+			);
+
+			// Assert old key existence using a unique sentinel value.
+			// ユニークなセンチネル値を使って旧キーの存在を検証する。
+			$sentinel         = 'vk_ltc_test_sentinel_not_found';
+			$old_key_result   = get_option( $old_key, $sentinel );
+			$old_key_actually = ( $sentinel !== $old_key_result );
+			$this->assertSame(
+				$case['expected']['old_key_exists'],
+				$old_key_actually,
+				$case['test_condition_name'] . ' (old key exists)'
+			);
+
+			// Clean up for next iteration.
+			// 次のイテレーションのためにクリーンアップする。
+			delete_option( $old_key );
+			delete_option( $new_key );
 		}
 	}
 }

--- a/tests/phpunit/test-uninstall.php
+++ b/tests/phpunit/test-uninstall.php
@@ -40,7 +40,8 @@ class UninstallTest extends WP_UnitTestCase {
 						),
 					),
 					'options'   => array(
-						'custom-post-types' => array( 'post', 'page' ),
+						'vk_ltc_custom_post_types' => array( 'post', 'page' ),
+						'custom-post-types'        => array( 'post' ),
 					),
 				),
 				'expected'           => array(
@@ -61,7 +62,7 @@ class UninstallTest extends WP_UnitTestCase {
 						),
 					),
 					'options'   => array(
-						'custom-post-types' => array( 'post' ),
+						'vk_ltc_custom_post_types' => array( 'post' ),
 					),
 				),
 				'expected'           => array(
@@ -154,12 +155,17 @@ class UninstallTest extends WP_UnitTestCase {
 				$case['test_condition_name'] . ' (vk-ltc-target post 2 should be deleted)'
 			);
 
-			// Assert option is deleted.
-			// オプションが削除されていることを確認する。
+			// Assert both new and legacy option keys are deleted.
+			// 新旧両方のオプションキーが削除されていることを確認する。
+			$this->assertSame(
+				$case['expected']['option'],
+				get_option( 'vk_ltc_custom_post_types', false ),
+				$case['test_condition_name'] . ' (vk_ltc_custom_post_types option)'
+			);
 			$this->assertSame(
 				$case['expected']['option'],
 				get_option( 'custom-post-types', false ),
-				$case['test_condition_name'] . ' (custom-post-types option)'
+				$case['test_condition_name'] . ' (legacy custom-post-types option)'
 			);
 
 			// Clean up for next iteration: delete any remaining meta and options.
@@ -168,6 +174,7 @@ class UninstallTest extends WP_UnitTestCase {
 			delete_post_meta( $post_id_1, 'vk-ltc-target' );
 			delete_post_meta( $post_id_2, 'vk-ltc-link' );
 			delete_post_meta( $post_id_2, 'vk-ltc-target' );
+			delete_option( 'vk_ltc_custom_post_types' );
 			delete_option( 'custom-post-types' );
 		}
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -9,7 +9,7 @@
  * Removes all plugin-specific data from the database:
  * データベースからプラグイン固有のデータを全て削除する:
  * - post meta: vk-ltc-link, vk-ltc-target
- * - option: custom-post-types
+ * - option: vk_ltc_custom_post_types (and legacy key: custom-post-types)
  *
  * @package vk-link-target-controller
  */
@@ -35,5 +35,11 @@ delete_post_meta_by_key( 'vk-ltc-target' );
 /**
  * Delete plugin options from the options table.
  * オプションテーブルからプラグインのオプションを削除する。
+ *
+ * Delete both the new prefixed key and the legacy key to ensure
+ * complete cleanup regardless of whether migration has occurred.
+ * 移行済みかどうかに関わらず完全にクリーンアップするため、
+ * 新しいプレフィックス付きキーとレガシーキーの両方を削除する。
  */
+delete_option( 'vk_ltc_custom_post_types' );
 delete_option( 'custom-post-types' );

--- a/vk-link-target-controller.php
+++ b/vk-link-target-controller.php
@@ -664,7 +664,28 @@ jQuery(document).ready(function($){
 			$post_types         = $this->get_public_post_types(); // array of post types to create a checkbox list
 			$post_types['page'] = __( 'Pages' );
 			$post_types_slugs   = array_keys( $post_types );
-			return get_option( 'vk_ltc_custom_post_types', $post_types_slugs );
+
+			// Use a sentinel value to distinguish "option not found" from a falsy stored value.
+			// センチネル値を使って「オプションが存在しない」と「falsy な保存値」を区別する。
+			$sentinel = 'vk_ltc_option_not_found';
+
+			// First, try the new option key.
+			// まず新しいオプションキーを試す。
+			$options = get_option( 'vk_ltc_custom_post_types', $sentinel );
+			if ( $sentinel !== $options ) {
+				return $options;
+			}
+
+			// Fall back to the legacy option key for environments where admin_init migration has not yet run.
+			// admin_init の移行処理がまだ実行されていない環境のために、旧オプションキーにフォールバックする。
+			$legacy_options = get_option( 'custom-post-types', $sentinel );
+			if ( $sentinel !== $legacy_options ) {
+				return $legacy_options;
+			}
+
+			// If neither key exists, return all public post type slugs as the default.
+			// どちらのキーも存在しない場合は、全公開投稿タイプのスラッグをデフォルトとして返す。
+			return $post_types_slugs;
 		}
 
 		/**

--- a/vk-link-target-controller.php
+++ b/vk-link-target-controller.php
@@ -287,7 +287,7 @@ if ( ! class_exists( 'VK_Link_Target_Controller' ) ) {
 
 				register_setting(
 					'vk-ltc-options',
-					'custom-post-types',
+					'vk_ltc_custom_post_types',
 					array( $this, 'sanitize_settings' )
 				); // create settings options in DB (use WordPress Settings API).
 			}
@@ -322,8 +322,8 @@ if ( ! class_exists( 'VK_Link_Target_Controller' ) ) {
 										$options_exist = $this->get_option() ? $this->get_option() : array();
 										$checked       = ( 0 != $options_exist && in_array( $slug, $options_exist ) ) ? 'checked="checked"' : '';
 										?>
-										<input type="checkbox" name="custom-post-types[]" id="custom-post-types-<?php echo $slug; ?>" value="<?php echo $slug; ?>" <?php echo $checked; ?> />
-										<label for="custom-post-types-<?php echo $slug; ?>"><?php echo $label; ?></label><br />
+										<input type="checkbox" name="vk_ltc_custom_post_types[]" id="vk_ltc_custom_post_types-<?php echo $slug; ?>" value="<?php echo $slug; ?>" <?php echo $checked; ?> />
+										<label for="vk_ltc_custom_post_types-<?php echo $slug; ?>"><?php echo $label; ?></label><br />
 																					<?php
 									}
 									?>
@@ -654,13 +654,17 @@ jQuery(document).ready(function($){
 		}
 
 		/**
-		 * default option
+		 * Get the saved option for enabled post types.
+		 * 有効な投稿タイプのオプション値を取得する。
+		 *
+		 * @access public
+		 * @return array Array of enabled post type slugs.
 		 */
 		function get_option() {
 			$post_types         = $this->get_public_post_types(); // array of post types to create a checkbox list
 			$post_types['page'] = __( 'Pages' );
 			$post_types_slugs   = array_keys( $post_types );
-			return get_option( 'custom-post-types', $post_types_slugs );
+			return get_option( 'vk_ltc_custom_post_types', $post_types_slugs );
 		}
 
 		/**
@@ -848,3 +852,46 @@ if ( isset( $vk_link_target_controller ) ) {
 	add_action( 'admin_menu', array( $vk_link_target_controller, 'create_settings_page' ) );
 	add_action( 'plugins_loaded', array( $vk_link_target_controller, 'translation' ) );
 }
+
+/**
+ * Migrate the option key from 'custom-post-types' to 'vk_ltc_custom_post_types'.
+ * オプションキーを 'custom-post-types' から 'vk_ltc_custom_post_types' に移行する。
+ *
+ * Runs on admin_init to handle existing installations.
+ * 既存インストールに対応するため admin_init で実行する。
+ * Only migrates if the old key exists in the database; once migrated, the old key
+ * is deleted so this check has no ongoing performance cost.
+ * 旧キーがデータベースに存在する場合のみ移行する。移行後は旧キーを削除するため、
+ * 以降のパフォーマンスコストはない。
+ *
+ * @return void
+ */
+function vk_ltc_migrate_option_key() {
+	$old_key   = 'custom-post-types';
+	$new_key   = 'vk_ltc_custom_post_types';
+	$sentinel  = 'vk_ltc_option_not_found';
+
+	// Check if the old option key exists in the database.
+	// Use a unique sentinel value to distinguish "key not found" from a stored value.
+	// 旧オプションキーがデータベースに存在するか確認する。
+	// ユニークなセンチネル値を使い、「キーが見つからない」と「保存された値」を区別する。
+	$old_value = get_option( $old_key, $sentinel );
+
+	// If the old key does not exist, no migration is needed.
+	// 旧キーが存在しない場合、移行は不要。
+	if ( $sentinel === $old_value ) {
+		return;
+	}
+
+	// Only migrate if the new key does not already have a value.
+	// 新キーにまだ値が設定されていない場合のみ移行する。
+	$new_value = get_option( $new_key, $sentinel );
+	if ( $sentinel === $new_value ) {
+		update_option( $new_key, $old_value );
+	}
+
+	// Delete the old option key after migration.
+	// 移行後に旧オプションキーを削除する。
+	delete_option( $old_key );
+}
+add_action( 'admin_init', 'vk_ltc_migrate_option_key' );


### PR DESCRIPTION
## 概要

オプションキー `custom-post-types` は汎用的な名前であり、同名オプションを使用する他のプラグインやテーマと衝突するリスクがあるため、プレフィックス付きキー `vk_ltc_custom_post_types` に変更します。

### 変更内容

- `register_setting()` のオプション名を `vk_ltc_custom_post_types` に変更
- 設定画面 HTML のフォーム要素（`name` / `id` / `for` 属性）を新キーに変更
- `get_option()` の参照先を新キーに変更
- 既存データの自動移行処理を追加（`admin_init` フックで旧キーから新キーへ移行し、旧キーを削除）
- `uninstall.php` で新旧両キーを削除するよう対応
- PHPUnit テストを新キーに更新し、移行処理のテストを追加

Closes #138

## 確認手順

### 前提条件
- VK Link Target Controller プラグインが有効化されていること
- 設定画面（管理画面 > 設定 > Link Target Controller）にアクセスできること

### 手順

#### 新規インストールの場合

1. 管理画面 > 設定 > Link Target Controller を開く
2. 投稿タイプのチェックボックス（例: 「Posts」「Pages」）にチェックを入れる
3. 「変更を保存」をクリックする
   → チェックした投稿タイプが保存され、ページリロード後もチェック状態が保持される
4. 投稿編集画面を開く
   → チェックした投稿タイプの編集画面に「URL to redirect to」メタボックスまたはサイドバーパネルが表示される
5. 別の投稿タイプ（チェックを入れていないもの）の編集画面を開く
   → メタボックス／パネルが表示されない

#### 既存インストールからのアップデートの場合（移行処理の確認）

1. master ブランチのプラグインを有効化し、設定画面で投稿タイプにチェックを入れて保存する
2. DBの `wp_options` テーブルに `custom-post-types` キーで値が保存されていることを確認する
3. このPRのブランチに切り替え、管理画面の任意のページを開く（admin_init が発火する）
4. 設定画面を開く
   → 以前チェックした投稿タイプのチェック状態がそのまま保持されている
5. DBの `wp_options` テーブルを確認する
   → `custom-post-types` キーが削除され、`vk_ltc_custom_post_types` キーに同じ値が保存されている

#### デグレ確認

1. 設定画面で投稿タイプのチェックを変更して保存する
   → 変更が正しく反映される
2. 投稿編集画面でリダイレクトURLを入力し、投稿を保存する
   → 公開側でリダイレクトが正しく動作する
3. 「別ウィンドウで開く」オプションを有効にして保存する
   → 公開側でリンクが別ウィンドウで開く

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * 変更履歴にオプションキー名の変更と移行手順についての記載を追加しました。

* **バグ修正**
  * 新しいプレフィックス付きオプションキーを優先し、見つからない場合は旧キーからフォールバックする挙動を導入しました。

* **改善**
  * アンインストール時に新旧両方のオプションキーが確実に削除されるようになりました。

* **テスト**
  * 新キー対応、移行、フォールバック、及びアンインストールの動作を検証する単体テストを追加・更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->