### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -5,8 +5,10 @@ on:
             - master
             - develop
             - ^feature/.+
+        types: [opened, reopened, labeled, synchronize]
 jobs:
     php_unit:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## 概要

GitHub Actions の消費削減のため、PHPUnit テストの実行トリガーを見直しました。push による自動実行を廃止し、PR は `run-ci` ラベルが付与されているときのみテストを実行するようにします。リリース時（タグ push）のテストは従来どおり維持します。

## 変更内容

- `.github/workflows/php_unit_test.yml`
    - `on.push` トリガーを削除（push での自動テスト実行を廃止）
    - `on.pull_request.types` に `[opened, reopened, labeled, synchronize]` を設定
    - テストジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加し、`run-ci` ラベル付き PR のときのみ実行

## 確認手順

1. ラベル無しの PR ではテストワークフローが起動しないこと
2. `run-ci` ラベルを付与するとテストワークフローが起動すること
3. ブランチへの push ではテストワークフローが起動しないこと
4. リリース時（タグ push など）は従来どおりテストが実行されること

CI 設定のみの変更であり、プラグインの動作には影響ありません。

関連: vektor-inc/multi-repo-tasks#24