### PR TITLE
[ セキュリティ修正 ] AJAX のリンクターゲット取得を公開済み投稿に限定

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -119,7 +119,7 @@ But we have a .pot file available so feel free to translate it in your language 
 
 == Changelog ==
 
-* [ Security Fix ] Limited AJAX link target data to published posts.
+* [ Security Fix ] Fixed an issue where the AJAX link target endpoint (`action=ids`) could expose link settings for non-published posts (e.g. drafts) to unauthenticated users. The query now explicitly limits results to published posts.
 * [ Bug Fix ] Fixed an undefined array key PHP warning on PHP 8.x when the nonce field is absent from the post save request.
 * [ Bug Fix ] Fixed an issue on the settings screen where styles and scripts could fail to update due to caching after an update, and an issue where the left side navigation could be cut off when notices were displayed.
 

--- a/readme.txt
+++ b/readme.txt
@@ -119,6 +119,7 @@ But we have a .pot file available so feel free to translate it in your language 
 
 == Changelog ==
 
+* [ Security Fix ] Limited AJAX link target data to published posts.
 * [ Bug Fix ] Fixed an undefined array key PHP warning on PHP 8.x when the nonce field is absent from the post save request.
 * [ Bug Fix ] Fixed an issue on the settings screen where styles and scripts could fail to update due to caching after an update, and an issue where the left side navigation could be cut off when notices were displayed.
 

--- a/vk-link-target-controller.php
+++ b/vk-link-target-controller.php
@@ -820,6 +820,7 @@ jQuery(document).ready(function($){
 				'posts_per_page' => -1,
 				'paged'          => 0,
 				'post_type'      => $post_types_slugs,
+				'post_status'    => 'publish',
 				'meta_key'       => 'vk-ltc-link',
 			);
 			$query = new WP_Query( $args );


### PR DESCRIPTION
## 概要

- AJAX のリンクターゲット取得処理で、取得対象を公開済み投稿に限定しました。
- `readme.txt` に Security Fix の changelog を追加しました。

Closes #158

## セキュリティ上の背景

フロント用 JS（`script.js`）は全ページで `admin-ajax.php?action=ids` を POST します。このエンドポイントは `wp_ajax_nopriv_ids` により **未ログインからも呼び出し可能** で、nonce チェックもありません。

修正前は `post_status` 未指定の `WP_Query` を使用していました。`admin-ajax.php` は `WP_ADMIN=true` を定義するため WP_Query が管理画面扱いとなり、`publish` 以外（`draft` / `pending` / `future` 等）の投稿も検索対象になり得ました。その結果、フロントに表示されていない下書き投稿のリンク設定（リダイレクト先 URL、パーマリンク等）が JSON で漏洩する可能性がありました。

本 PR では `post_status => 'publish'` を明示し、フロント向けデータを公開済み投稿のみに限定します。

## 再現（修正前）

1. 下書き投稿に `vk-ltc-link` を設定する（リダイレクト先 URL も分かる値にしておく）

2. **未ログイン状態**で以下いずれかの方法で確認

   **事前準備**
   - WordPress からログアウトする（またはシークレット / プライベートウィンドウを使う）
   - 対象サイトのフロントページ（トップページ等）を開く

   **方法A: Network タブで確認（プラグイン JS の自動リクエストを見る）**

   1. `F12`（Mac: `Option + Command + I`）で開発者ツールを開く
   2. **Network（ネットワーク）** タブを選択
   3. ページをリロード（`Cmd + R` / `Ctrl + R`）
   4. フィルタ欄に `admin-ajax` と入力
   5. `admin-ajax.php` のリクエストをクリック
   6. **Payload（ペイロード）** に `action: ids` があることを確認
   7. **Response（レスポンス）** タブを開き、JSON を確認

   **方法B: Console タブで手動実行（curl と同等の確認）**

   1. 未ログインのまま、対象サイトのフロントページで開発者ツールを開く
   2. **Console（コンソール）** タブを選択
   3. 以下を貼り付けて Enter:

   ```javascript
   fetch('/wp-admin/admin-ajax.php', {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: 'action=ids',
   })
     .then((response) => response.text())
     .then((data) => console.log(JSON.parse(data)));
   ```

   4. Console に表示された JSON を確認

   **方法C: ターミナル（curl）**

   ```bash
   curl -X POST 'https://example.com/wp-admin/admin-ajax.php' -d 'action=ids'
   ```

3. **期待結果**
   - **修正前**: 下書き投稿の ID をキーとしたオブジェクトが JSON に含まれ、`re`（リダイレクト先 URL）・`pl`（パーマリンク）・`tg`（別ウィンドウフラグ）等が見える
   - **修正後**: `publish` の投稿のみ返る（下書きの ID は含まれない）

   ※ 方法A は一般訪問者がページを見るだけでも同リクエストが自動送信されるため、最も実際の利用に近い確認方法です。

## 確認

- `php -l vk-link-target-controller.php`
  → No syntax errors detected in vk-link-target-controller.php
- `git diff --check`
  → 問題なし
- `npm test`
  → `node --check js/script.js && node --check js/admin-link-dialog.js` が成功

## 補足

- 表示/UI変更ではないためスクリーンショットは省略しています。
- 管理画面（メタボックス / REST API）でのリンク設定は従来どおり下書き等でも可能です。本修正はフロント向け AJAX レスポンスのみが対象です。