### PR TITLE
[ 開発環境 ] リリースワークフローの wp-env override ファイル名を .wp-env.override.json に修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,10 +133,10 @@ jobs:
                     [ -f "$f" ] && cp "$f" "dist/${{ env.plugin_name }}/$f" || true
                   done
                   [ -d tests ] && cp -r tests "dist/${{ env.plugin_name }}/tests" || true
-            - name: Create wp-env.override.json for dist
+            - name: Create .wp-env.override.json for dist
               run: |
-                  printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > wp-env.override.json
-            - name: Install several WordPress version by wp-env.override.json
+                  printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > .wp-env.override.json
+            - name: Install several WordPress version by .wp-env.override.json
               run: |
                   n=0
                   until (( n >= 5 ))


### PR DESCRIPTION
## 概要

リリースワークフロー `.github/workflows/release.yml` の `php_unit` ジョブで、wp-env の override 設定ファイルを先頭ドット無しの `wp-env.override.json` という名前で生成していた。wp-env（`@wordpress/env`）は `.wp-env.override.json`（先頭ドット有り）しか読み込まないため、この override が効かず、**dist（配布ビルド）ではなく source を検証してしまっていた**。ファイル名を `.wp-env.override.json` に統一してこの不備を解消する。

vektor-inc/vk-agents#168 の C-7 移行不備監査のフォローアップ。

関連 issue: https://github.com/vektor-inc/vk-link-target-controller/issues/157

## 変更内容

`.github/workflows/release.yml` の 3 箇所を `wp-env.override.json` → `.wp-env.override.json`（先頭ドット付き）に修正:

- ステップ名 `Create wp-env.override.json for dist`
- `printf ... > wp-env.override.json` のリダイレクト先
- ステップ名 `Install several WordPress version by wp-env.override.json`

### 補足（スコープ判断）

- `.github/workflows/php_unit_test.yml` にもステップ名に同名文字列があるが、そちらは実際に override ファイルを **生成しておらず**、`npm run wp-env start` で source をビルド検証する通常の CI であり正しい挙動のため、**対象外**とした。今回の変更は `release.yml` のみ。
- changelog は追記していない。GitHub Actions ワークフロー設定の修正で配布物にも含まれずエンドユーザーに影響しないため（`rules/changelog.md`「更新不要なケース: GitHub Actions などのワークフロー設定」に該当）。

## テスト（確認手順）

このワークフローはタグ push 時にのみ動作するため、実機での事前確認は CI 実行時に行う。

**Before（修正前の問題）**
- `php_unit` ジョブが `wp-env.override.json`（ドット無し）を生成 → wp-env が読み込まず、`.wp-env.json` の `"plugins": ["."]`（source）を検証していた。

**After（修正後の確認）**
1. リリースタグ（例 `x.y.z`）を push し release.yml を起動する。
2. `php_unit` ジョブの「Create .wp-env.override.json for dist」ステップで `.wp-env.override.json` が生成されることをログで確認する。
   → wp-env が override を読み込み、`./dist/vk-link-target-controller`（配布ビルド）が PHPUnit の検証対象になる。
3. `php_unit` の各マトリクス（PHP 7.4/8.1 × WP 6.7/6.8/6.9）がグリーンであることを確認する。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/274