### PR TITLE
[ 不具合修正 ] 1.10.2 リリース（未反映の修正 + Tested up to 7.1 更新）

### DIFF
--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['7.4', '8.2', '8.4']
-                wp-versions: ['6.7', '6.8', '6.9']
+                wp-versions: ['6.7', '6.8', '6.9', '7.0']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['7.4', '8.1']
-                wp-versions: ['6.7', '6.8', '6.9']
+                wp-versions: ['6.7', '6.8', '6.9', '7.0']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: redirection,link,recent posts,list,page,post
 Requires at least: 5.3
 Tested up to: 7.1
-Stable tag: 1.10.1
+Stable tag: 1.10.2
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -27,7 +27,7 @@ Fast redirection to the product you want to sell!.
 = GitHub repository =
 
 VK Link Target Controller official repository on GitHub.
-[https://github.com/kurudrive/vk-link-target-controller](https://github.com/kurudrive/vk-link-target-controller)
+[https://github.com/vektor-inc/vk-link-target-controller](https://github.com/vektor-inc/vk-link-target-controller)
 Latest plugin version is always on GitHub.
 
 == Installation ==
@@ -89,7 +89,7 @@ Your theme probably has it if it follows the WordPress Theme recommendations.
 Example A:
 `
 <div class="post-item post-block front-page-list post-<?php the_ID(); ?>" id="post-<?php the_ID(); ?>">
-	<a href="<?php the permalink(); ?>">
+	<a href="<?php the_permalink(); ?>">
  		<?php the_title(); ?>
 	</a>
 </div>
@@ -119,9 +119,11 @@ But we have a .pot file available so feel free to translate it in your language 
 
 == Changelog ==
 
+= 1.10.2 =
 * [ Security Fix ] Fixed an issue where the AJAX link target endpoint (`action=ids`) could expose link settings for non-published posts (e.g. drafts) to unauthenticated users. The query now explicitly limits results to published posts.
 * [ Bug Fix ] Fixed an undefined array key PHP warning on PHP 8.x when the nonce field is absent from the post save request.
 * [ Bug Fix ] Fixed an issue on the settings screen where styles and scripts could fail to update due to caching after an update, and an issue where the left side navigation could be cut off when notices were displayed.
+* [ Other ] Tested up to WordPress 7.1.
 
 = 1.10.1 =
 * [ Bug Fix ] Fixed an issue where the redirect URL could not be saved, displayed, or updated on custom post types. The fix covers CPTs registered later by other plugins (e.g. CPT UI, ExUnit), CPTs with a customized `capability_type` (e.g. a CPT using `edit_sites` instead of `edit_posts`), and CPTs that do not declare `custom-fields` post_type support.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: vektor-inc,kurudrive,dswebstudio,bizvektor,nc30,catherine8007,rick
 Donate link:
 Tags: redirection,link,recent posts,list,page,post
 Requires at least: 5.3
-Tested up to: 6.9
+Tested up to: 7.1
 Stable tag: 1.10.1
 License: GPL2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/vk-link-target-controller.php
+++ b/vk-link-target-controller.php
@@ -3,7 +3,7 @@
 Plugin Name: VK Link Target Controller
 Plugin URI: https://github.com/vektor-inc/vk-link-target-controller
 Description: Allow you to link a post title from the recent posts list to another page (internal or external link) rather than link to the actual post page
-Version: 1.10.1
+Version: 1.10.2
 Author: Vektor,Inc.
 Author URI: http://www.vektor-inc.co.jp/
 License: GPL2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

- コミュニティ（genepine さん）から WordPress 7.1 向けの動作確認バージョン更新依頼
- **1.10.1 タグ以降、master にマージ済みのセキュリティ修正・不具合修正が WordPress.org 未リリースのまま残っている**ため、1.10.2 として整理してリリースする

## どういう変更をしたか？

* バージョンを **1.10.2** に更新（`vk-link-target-controller.php` / `readme.txt` Stable tag）
* `readme.txt` の Changelog を整理（バージョン見出しなしで放置されていた 3 件を `= 1.10.2 =` 配下へ移動）
* `Tested up to: 7.1` を更新
* `readme.txt` の GitHub リポジトリ URL を `vektor-inc` に修正
* FAQ サンプルコードの `the permalink()` → `the_permalink()` typo を修正
* CI（`php_unit_test.yml` / `release.yml`）の PHPUnit マトリクスに WordPress **7.0** を追加

## レビューに回す前に確認する事

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？（コード変更なし。バージョン・readme・CI のみ）

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

* `1.10.1` タグ以降の master に #150 / #154 / #159 の修正が入っているが Stable tag が 1.10.1 のままであることを `git log 1.10.1..master` で確認
* Changelog の orphan エントリ 3 件が該当修正と一致することを目視確認
* `npm test`（JS 構文チェック）: 成功
* WP 7.1 上での PHPUnit: この Cloud Agent 環境に Docker がないため未実行
* WordPress Git タグ: `7.1` は未作成のため CI は `7.0` のみ追加（`Tested up to: 7.1` はコミュニティ検証に基づく宣言）

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

* `Stable tag` / プラグインヘッダーが `1.10.2` になっていること
* Changelog の `= 1.10.2 =` 配下に #150 / #154 / #159 の内容が正しく記載されていること
* `Tested up to: 7.1` になっていること
* マージ後、タグ `1.10.2` を打てば release ワークフロー経由で WordPress.org にデプロイされること

## レビュワーに回す前の確認事項

- [x] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cae4d00a-f9df-4404-a9a2-b90c47919368?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cae4d00a-f9df-4404-a9a2-b90c47919368&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

